### PR TITLE
Limit regex string matching to 100 characters max

### DIFF
--- a/src/emojideno.ts
+++ b/src/emojideno.ts
@@ -1,7 +1,7 @@
 import { EMOJIS, EMOJIS_ALIAS } from "./constants.ts";
 
 export function emojize(text: string) {
-  return text.replace(/(:[a-zA-Z0-9\+\-_&.ô’Åéãíç()!#*]+:)/g, replacerHandler);
+  return text.replace(/(:[a-zA-Z0-9\+\-_&.ô’Åéãíç()!#*]{1,100}:)/g, replacerHandler);
 }
 
 function replacerHandler(match: string): string {


### PR DESCRIPTION
This should improve performance in the case of a large string with dangling colons and prevent a potential DDoS vector.

I just did a quick pass at the constants file, and the longest string I saw was around 50 characters, you may want to make the max the longest string for matching, but 100 is probably safe.